### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/.github/workflows/platformer-188b2e79-ecc9-428e-a9b8-f689ba17d909.yml
+++ b/.github/workflows/platformer-188b2e79-ecc9-428e-a9b8-f689ba17d909.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on:
       - ubuntu-latest
     env:
-      SERVICE_NAME: ghrc.io/test
+      SERVICE_NAME: ghcr.io/test
     steps:
       - uses: actions/checkout@v2
       - name: Set Version


### PR DESCRIPTION
Hi `chamodshehanka/ajax-zero-hero`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.